### PR TITLE
Error on block:drag:stop

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -37,6 +37,8 @@ const plugin: Plugin<PluginOptions> = (editor, options) => {
     })
 
     editor.on('block:drag:stop', (component: Component) => {
+      if (!component) return
+
       const {
         'data-type': componentType
       } = component.getAttributes()


### PR DESCRIPTION
Fix "TypeError: d is null" when block is dragged and dropped outside canvas (for example in blocks panel)